### PR TITLE
fix: dep issues with the root package.json that's breaking eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,6 @@
       "devDependencies": {
         "@commitlint/cli": "^16.2.3",
         "@commitlint/config-conventional": "^16.2.1",
-        "eslint": "^8.12.0",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-jest": "^26.1.3",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.0.0",
-        "eslint-plugin-unicorn": "^41.0.1",
         "husky": "^7.0.4",
         "lerna": "^4.0.0"
       },
@@ -972,6 +966,7 @@
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.1",
       "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -995,6 +990,7 @@
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
       "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -1006,7 +1002,8 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "peer": true
     },
     "node_modules/@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -2933,6 +2930,7 @@
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -3087,7 +3085,8 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "peer": true
     },
     "node_modules/aria-query": {
       "version": "5.0.0",
@@ -4302,6 +4301,7 @@
     "node_modules/doctrine": {
       "version": "3.0.0",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -4574,6 +4574,7 @@
     "node_modules/eslint": {
       "version": "8.12.0",
       "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.1",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -5314,6 +5315,7 @@
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5324,6 +5326,7 @@
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.1.1",
       "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -5335,6 +5338,7 @@
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -5345,6 +5349,7 @@
     "node_modules/espree": {
       "version": "9.3.1",
       "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
@@ -5559,6 +5564,7 @@
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -5598,6 +5604,7 @@
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "peer": true,
       "dependencies": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -5608,7 +5615,8 @@
     },
     "node_modules/flatted": {
       "version": "3.2.5",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "peer": true
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -6050,6 +6058,7 @@
     "node_modules/globals": {
       "version": "13.13.0",
       "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -6063,6 +6072,7 @@
     "node_modules/globals/node_modules/type-fest": {
       "version": "0.20.2",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7498,6 +7508,7 @@
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7632,7 +7643,8 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "peer": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -7788,6 +7800,7 @@
     "node_modules/levn": {
       "version": "0.4.1",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -7987,7 +8000,8 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "peer": true
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -9003,6 +9017,7 @@
     "node_modules/optionator": {
       "version": "0.9.1",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -9482,6 +9497,7 @@
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -11222,7 +11238,8 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "peer": true
     },
     "node_modules/throat": {
       "version": "6.0.1",
@@ -11404,6 +11421,7 @@
     "node_modules/type-check": {
       "version": "0.4.0",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -11561,7 +11579,8 @@
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "peer": true
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.0",
@@ -12767,6 +12786,7 @@
     "@eslint/eslintrc": {
       "version": "1.2.1",
       "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "peer": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -12787,6 +12807,7 @@
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "peer": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -12795,7 +12816,8 @@
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "peer": true
     },
     "@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -14376,6 +14398,7 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "peer": true,
       "requires": {}
     },
     "acorn-walk": {
@@ -14496,7 +14519,8 @@
     },
     "argparse": {
       "version": "2.0.1",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "peer": true
     },
     "aria-query": {
       "version": "5.0.0",
@@ -15404,6 +15428,7 @@
     "doctrine": {
       "version": "3.0.0",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "peer": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -15610,6 +15635,7 @@
     "eslint": {
       "version": "8.12.0",
       "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.2.1",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -15650,11 +15676,13 @@
       "dependencies": {
         "escape-string-regexp": {
           "version": "4.0.0",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "peer": true
         },
         "eslint-scope": {
           "version": "7.1.1",
           "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "peer": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^5.2.0"
@@ -15663,6 +15691,7 @@
         "glob-parent": {
           "version": "6.0.2",
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "peer": true,
           "requires": {
             "is-glob": "^4.0.3"
           }
@@ -16138,6 +16167,7 @@
     "espree": {
       "version": "9.3.1",
       "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "peer": true,
       "requires": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
@@ -16300,6 +16330,7 @@
     "file-entry-cache": {
       "version": "6.0.1",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "peer": true,
       "requires": {
         "flat-cache": "^3.0.4"
       }
@@ -16327,6 +16358,7 @@
     "flat-cache": {
       "version": "3.0.4",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "peer": true,
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -16334,7 +16366,8 @@
     },
     "flatted": {
       "version": "3.2.5",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "peer": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -16671,13 +16704,15 @@
     "globals": {
       "version": "13.13.0",
       "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "peer": true,
       "requires": {
         "type-fest": "^0.20.2"
       },
       "dependencies": {
         "type-fest": {
           "version": "0.20.2",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "peer": true
         }
       }
     },
@@ -17741,6 +17776,7 @@
     "js-yaml": {
       "version": "4.1.0",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "peer": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -17845,7 +17881,8 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "peer": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -17966,6 +18003,7 @@
     "levn": {
       "version": "0.4.1",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "peer": true,
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -18135,7 +18173,8 @@
     },
     "lodash.merge": {
       "version": "4.6.2",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "peer": true
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -18907,6 +18946,7 @@
     "optionator": {
       "version": "0.9.1",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "peer": true,
       "requires": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -19237,7 +19277,8 @@
     },
     "prelude-ls": {
       "version": "1.2.1",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "peer": true
     },
     "prettier": {
       "version": "2.6.2",
@@ -20519,7 +20560,8 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "peer": true
     },
     "throat": {
       "version": "6.0.1",
@@ -20651,6 +20693,7 @@
     "type-check": {
       "version": "0.4.0",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "peer": true,
       "requires": {
         "prelude-ls": "^1.2.1"
       }
@@ -20766,7 +20809,8 @@
     },
     "v8-compile-cache": {
       "version": "2.3.0",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "peer": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,6 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",
-    "eslint": "^8.12.0",
-    "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-jest": "^26.1.3",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-unicorn": "^41.0.1",
     "husky": "^7.0.4",
     "lerna": "^4.0.0"
   },


### PR DESCRIPTION
ESLint deps being in the root `package.json` file are currently breaking ESLint in CI: https://github.com/readmeio/standards/runs/5824177810?check_suite_focus=true