### PR TITLE
chore: add "version" step to keep package-lock in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "lint": "npx lerna run lint --stream",
     "prepare": "husky install",
+    "version": "npm i && git add package-lock.json",
     "release": "npx lerna publish",
     "test": "npx lerna run test --stream"
   },


### PR DESCRIPTION
| 🚥 Fix RM-XXX |
| :-- |

## 🧰 Changes

Reference to Lerna's lifecycle sequence:
https://github.com/lerna/lerna/tree/main/commands/version#lifecycle-scripts

When Lerna independently bumps new versions for all *changed* packages,
the root `package-lock.json` file also needs to be updated for
record-keeping. Otherwise, CI checks will fail. However Lerna does not
do this automatically for us.

Step 4 in the versioning sequence is where we add a custom step to
update our `package-lock.json` by running an `npm install` and then
immediately staging it. Step 5 and 6 will then include it when issuing
the commit. 🎉


## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
