### PR TITLE
fix(eslint-config): fix false-positive error with TS enums

### DIFF
--- a/packages/eslint-config/typescript.js
+++ b/packages/eslint-config/typescript.js
@@ -36,5 +36,10 @@ module.exports = {
     // enums are used before they're defined -- eventhough in TS that's OK.
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': ['error'],
+
+    // The stock `no-shadow` ESLint rule throws false positive with TS enums.
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2483
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
   },
 };


### PR DESCRIPTION
| 🚥 Fix RM-XXX |
| :-- |

## 🧰 Changes

Issue reference:
https://github.com/typescript-eslint/typescript-eslint/issues/2483

Fixes the false-positive error when declaring enums like this:
```ts
export enum Type {
  Dialog = 'dialog',
  ActionSheet = 'actionSheet',
}
```


## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
