### PR TITLE
Update stylelint rules for ReadMe ID selector patterns

### DIFF
--- a/packages/stylelint-config/__tests__/__snapshots__/index.js.snap
+++ b/packages/stylelint-config/__tests__/__snapshots__/index.js.snap
@@ -12,6 +12,14 @@ exports[`stylelint-config with an invalid file and auto-fix enabled matches the 
   --brand-red: hsl(5deg 10% 40%);
 }
 
+#id-selector {
+  color: blue;
+
+  #another-id {
+    border: 0;
+  }
+}
+
 .selector-1,
 .selector-2,
 .selector-3[type=\\"text\\"] {

--- a/packages/stylelint-config/__tests__/__snapshots__/index.js.snap
+++ b/packages/stylelint-config/__tests__/__snapshots__/index.js.snap
@@ -20,6 +20,14 @@ exports[`stylelint-config with an invalid file and auto-fix enabled matches the 
   }
 }
 
+#ValidIdSelector {
+  padding: 0;
+}
+
+#badIdSelector {
+  border: 0;
+}
+
 .selector-1,
 .selector-2,
 .selector-3[type=\\"text\\"] {

--- a/packages/stylelint-config/__tests__/index.js
+++ b/packages/stylelint-config/__tests__/index.js
@@ -7,6 +7,7 @@ const validScss = fs.readFileSync('./__tests__/valid.scss', 'utf-8');
 
 describe('stylelint-config', () => {
   let data;
+  let warnings;
 
   describe('with a valid file', () => {
     beforeEach(async () => {
@@ -14,6 +15,7 @@ describe('stylelint-config', () => {
         code: validScss,
         config,
       });
+      ({ warnings } = data.results[0]);
     });
 
     it('has no errors', () => {
@@ -21,7 +23,7 @@ describe('stylelint-config', () => {
     });
 
     it('flags no warnings', () => {
-      expect(data.results[0].warnings).toHaveLength(0);
+      expect(warnings).toHaveLength(0);
     });
   });
 
@@ -32,6 +34,7 @@ describe('stylelint-config', () => {
         config,
         fix: true,
       });
+      ({ warnings } = data.results[0]);
     });
 
     it('matches the auto-fixed snapshot', () => {
@@ -43,7 +46,11 @@ describe('stylelint-config', () => {
     });
 
     it('flags warnings', () => {
-      expect(data.results[0].warnings).toHaveLength(4);
+      expect(warnings).toHaveLength(5);
+    });
+
+    it('expects no more than 1 id selector', () => {
+      expect(warnings.some(w => w.rule === 'selector-max-id')).toBeTruthy();
     });
   });
 });

--- a/packages/stylelint-config/__tests__/index.js
+++ b/packages/stylelint-config/__tests__/index.js
@@ -46,11 +46,15 @@ describe('stylelint-config', () => {
     });
 
     it('flags warnings', () => {
-      expect(warnings).toHaveLength(5);
+      expect(warnings).toHaveLength(6);
     });
 
     it('expects no more than 1 id selector', () => {
       expect(warnings.some(w => w.rule === 'selector-max-id')).toBeTruthy();
+    });
+
+    it('expects id pattern to be either kebab-case or TitleCase', () => {
+      expect(warnings.some(w => w.rule === 'selector-id-pattern')).toBeTruthy();
     });
   });
 });

--- a/packages/stylelint-config/__tests__/invalid.scss
+++ b/packages/stylelint-config/__tests__/invalid.scss
@@ -9,6 +9,14 @@
   --brand-red: hsl(5deg 10% 40%);
 }
 
+#id-selector {
+  color: blue;
+
+  #another-id {
+    border: 0;
+  }
+}
+
 .selector-1,
 .selector-2,
 .selector-3[type="text"] {

--- a/packages/stylelint-config/__tests__/invalid.scss
+++ b/packages/stylelint-config/__tests__/invalid.scss
@@ -17,6 +17,14 @@
   }
 }
 
+#ValidIdSelector {
+  padding: 0px 0px 0px;
+}
+
+#badIdSelector {
+  border: 0;
+}
+
 .selector-1,
 .selector-2,
 .selector-3[type="text"] {

--- a/packages/stylelint-config/__tests__/valid.scss
+++ b/packages/stylelint-config/__tests__/valid.scss
@@ -13,6 +13,10 @@
   color: blue;
 }
 
+#ValidIdSelector {
+  padding: 0;
+}
+
 .selector-1,
 .selector-2,
 .selector-3[type="text"] {

--- a/packages/stylelint-config/__tests__/valid.scss
+++ b/packages/stylelint-config/__tests__/valid.scss
@@ -9,6 +9,10 @@
   --brand-red: rgb(112, 94, 92);
 }
 
+#id-selector {
+  color: blue;
+}
+
 .selector-1,
 .selector-2,
 .selector-3[type="text"] {

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -17,19 +17,6 @@ module.exports = {
     'stylelint-prettier/recommended',
   ],
   rules: {
-    // ReadMe still uses color names as values in many places.
-    'color-named': null,
-
-    // ReadMe breaks this rule in many places.
-    'max-nesting-depth': null,
-
-    // ReadMe still references elements by #id. Allow at most one per selector.
-    'selector-max-id': 1,
-
-    // ReadMe relies on "element[attr='value']" selectors in too many places.
-    // Eventually, it may be beneficial to turn this on.
-    'selector-no-qualifying-type': null,
-
     // ReadMe relies on legacy color functions (e.g. rgba(0, 0, 0, 0.5))
     // everywhere in addition to Scss allowing this to be written with a color
     // name (e.g. rgba(black, 0.5)). Eventually, consider removing this rule to
@@ -37,13 +24,11 @@ module.exports = {
     // change however won't be trivial.
     'color-function-notation': 'legacy',
 
-    // Custom regex for ReadMe id patterns.
-    'selector-id-pattern': [
-      '^(([a-z][a-z0-9]*(-[a-z0-9]+)*)|([A-Z][a-z0-9]*)+)$',
-      {
-        message: 'Expected id selector to be kebab-case or TitleCase',
-      },
-    ],
+    // ReadMe still uses color names as values in many places.
+    'color-named': null,
+
+    // ReadMe breaks this rule in many places.
+    'max-nesting-depth': null,
 
     // Custom regex of ReadMe's current BEM selector class pattern.
     'selector-class-pattern': [
@@ -53,6 +38,21 @@ module.exports = {
           'Selector should start in CapitalCase or camelCase and optionally followed by either kebab-lowercase with hyphens or snake_lowercase with underscores (e.g. BlockName-element-name_modifier-name)',
       },
     ],
+
+    // Custom regex for ReadMe id patterns.
+    'selector-id-pattern': [
+      '^(([a-z][a-z0-9]*(-[a-z0-9]+)*)|([A-Z][a-z0-9]*)+)$',
+      {
+        message: 'Expected id selector to be kebab-case or TitleCase',
+      },
+    ],
+
+    // ReadMe still references elements by #id. Allow at most one per selector.
+    'selector-max-id': 1,
+
+    // ReadMe relies on "element[attr='value']" selectors in too many places.
+    // Eventually, it may be beneficial to turn this on.
+    'selector-no-qualifying-type': null,
 
     // TODO: Remove this when migrating to Dart Sass.
     // Disallows the use of global function names, as these global functions are

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -23,6 +23,9 @@ module.exports = {
     // ReadMe breaks this rule in many places.
     'max-nesting-depth': null,
 
+    // ReadMe still references elements by #id. Allow at most one per selector.
+    'selector-max-id': 1,
+
     // ReadMe relies on "element[attr='value']" selectors in too many places.
     // Eventually, it may be beneficial to turn this on.
     'selector-no-qualifying-type': null,

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -37,6 +37,14 @@ module.exports = {
     // change however won't be trivial.
     'color-function-notation': 'legacy',
 
+    // Custom regex for ReadMe id patterns.
+    'selector-id-pattern': [
+      '^(([a-z][a-z0-9]*(-[a-z0-9]+)*)|([A-Z][a-z0-9]*)+)$',
+      {
+        message: 'Expected id selector to be kebab-case or TitleCase',
+      },
+    ],
+
     // Custom regex of ReadMe's current BEM selector class pattern.
     'selector-class-pattern': [
       '^[a-zA-Z0-9]+((_|-)([a-zA-Z0-9]+))*$',


### PR DESCRIPTION
| 🚥 Fix RM-XXX |
| :-- |

## 🧰 Changes

### feat(stylelint-config): allow use of at most one ID selector

ReadMe still has cases where it names and references elements by #id.
So make an exception for that but limit this to at most one ID max per
selector. In other words, never allow something like `#one #two {...}`.

### feat(stylelint-config): allow TitleCased selector id patterns 

By default, all ids are expected to be kebab-cased. However, ReadMe
still uses TitleCased ids, similar to its Component BEM class name
patterns.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
