### PR TITLE
feat(stylelint): use "simple" selector-not-notation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,5 @@ jobs:
         run: npm install -g npm@8
 
       - run: npm ci
+      - run: npm lint
       - run: npm test

--- a/packages/stylelint-config/__tests__/__snapshots__/index.js.snap
+++ b/packages/stylelint-config/__tests__/__snapshots__/index.js.snap
@@ -103,5 +103,12 @@ exports[`stylelint-config with an invalid file and auto-fix enabled matches the 
     opacity: 1;
   }
 }
+
+// Prefer "simple" selector-not-notation
+.selector-not-notation {
+  &:not(.one):not(.two):not(.three) {
+    display: block;
+  }
+}
 "
 `;

--- a/packages/stylelint-config/__tests__/index.js
+++ b/packages/stylelint-config/__tests__/index.js
@@ -1,6 +1,8 @@
-const config = require('..');
 const fs = require('fs');
+
 const stylelint = require('stylelint');
+
+const config = require('..');
 
 const invalidScss = fs.readFileSync('./__tests__/invalid.scss', 'utf-8');
 const validScss = fs.readFileSync('./__tests__/valid.scss', 'utf-8');
@@ -55,6 +57,10 @@ describe('stylelint-config', () => {
 
     it('expects id pattern to be either kebab-case or TitleCase', () => {
       expect(warnings.some(w => w.rule === 'selector-id-pattern')).toBeTruthy();
+    });
+
+    it('auto-fixes "selector-not-notation" to "simple" pattern', () => {
+      expect(data.output).toContain('&:not(.one):not(.two):not(.three)');
     });
   });
 });

--- a/packages/stylelint-config/__tests__/invalid.scss
+++ b/packages/stylelint-config/__tests__/invalid.scss
@@ -93,3 +93,10 @@
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+// Prefer "simple" selector-not-notation
+.selector-not-notation {
+  &:not(.one, .two, .three) {
+    display: block;
+  }
+}

--- a/packages/stylelint-config/__tests__/valid.scss
+++ b/packages/stylelint-config/__tests__/valid.scss
@@ -92,3 +92,10 @@
     opacity: 1;
   }
 }
+
+// Prefer "simple" selector-not-notation
+.selector-not-notation {
+  &:not(.one):not(.two):not(.three) {
+    display: block;
+  }
+}

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -54,6 +54,12 @@ module.exports = {
     // Eventually, it may be beneficial to turn this on.
     'selector-no-qualifying-type': null,
 
+    // Complex selectors are a level 4 spec that is not yet fully supported by
+    // all browsers, e.g. `:not(one, two, three)`. Until then, prefer the simple
+    // pattern that we use today, e.g. `:not(one):not(two):not(three)`.
+    // https://stylelint.io/user-guide/rules/list/selector-not-notation/
+    'selector-not-notation': 'simple',
+
     // TODO: Remove this when migrating to Dart Sass.
     // Disallows the use of global function names, as these global functions are
     // now located inside built-in Dart Sass modules.


### PR DESCRIPTION
| 🚥 Fix RM-XXX |
| :-- |

## 🧰 Changes

- feat(stylelint): use "simple" selector-not-notation
- chore: run lint on github action workflow

Complex selectors inside the `:not()` notation are not yet fully
supported by browsers and has caused some regressions for us.
https://github.com/readmeio/readme/pull/7511
https://linear.app/readme-io/issue/RM-5144/left-side-navigation-inaccessible-when-viewport-is-between-768-and

Use "simple" notation instead in the meantime. This is what we currently
use today.

Rule reference:
https://stylelint.io/user-guide/rules/list/selector-not-notation/


## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
