### PR TITLE
fix(stylelint-config): disable media-query-no-invalid rule

### DIFF
--- a/packages/stylelint-config/__tests__/__snapshots__/index.js.snap
+++ b/packages/stylelint-config/__tests__/__snapshots__/index.js.snap
@@ -4,6 +4,9 @@ exports[`stylelint-config with an invalid file and auto-fix enabled matches the 
 "@import "x.css";
 @import "y.css";
 
+$one: "one";
+$twoCamelCase: "two";
+
 /**
  * Multi-line comment
  */
@@ -33,8 +36,8 @@ exports[`stylelint-config with an invalid file and auto-fix enabled matches the 
 .selector-3[type="text"] {
   background: linear-gradient(#fff, rgb(0 0 0 / 0.8));
   box-sizing: border-box;
-  display: block;
   color: var(--brand-red);
+  display: block;
 }
 
 .selector-a,
@@ -81,16 +84,16 @@ exports[`stylelint-config with an invalid file and auto-fix enabled matches the 
       #fff 25px,
       rgb(255 255 255 / 1) 50px
     );
-    margin: 10px;
-    margin-bottom: 5px;
     box-shadow: 0 1px 1px #000, 0 1px 0 #fff, 2px 2px 1px 1px #ccc inset;
     height: 10rem;
+    margin: 10px;
+    margin-bottom: 5px;
   }
 
   /* Flush nested single line comment */
   .selector::after {
-    content: "→";
     background-image: url("x.svg");
+    content: "→";
   }
 }
 

--- a/packages/stylelint-config/__tests__/index.js
+++ b/packages/stylelint-config/__tests__/index.js
@@ -48,7 +48,26 @@ describe('stylelint-config', () => {
     });
 
     it('flags warnings', () => {
-      expect(warnings).toHaveLength(6);
+      expect(warnings).toContainEqual(
+        expect.objectContaining({
+          text: expect.stringMatching(/scss\/dollar-variable-pattern/),
+        })
+      );
+      expect(warnings).toContainEqual(
+        expect.objectContaining({
+          text: expect.stringMatching(/color-function-notation/),
+        })
+      );
+      expect(warnings).toContainEqual(
+        expect.objectContaining({
+          text: expect.stringMatching(/selector-id-pattern/),
+        })
+      );
+      expect(warnings).toContainEqual(
+        expect.objectContaining({
+          text: expect.stringMatching(/selector-max-id/),
+        })
+      );
     });
 
     it('expects no more than 1 id selector', () => {

--- a/packages/stylelint-config/__tests__/invalid.scss
+++ b/packages/stylelint-config/__tests__/invalid.scss
@@ -1,6 +1,9 @@
 @import url("x.css");
 @import url("y.css");
 
+$one: "one";
+$twoCamelCase: "two";
+
 /**
  * Multi-line comment
  */
@@ -40,9 +43,15 @@
   top: calc(100% - 2rem);
 }
 
-.selector-x { width: 10%; }
-.selector-y { width: 20%; }
-.selector-z { width: 30%; }
+.selector-x {
+  width: 10%;
+}
+.selector-y {
+  width: 20%;
+}
+.selector-z {
+  width: 30%;
+}
 
 /* Single-line comment */
 
@@ -61,24 +70,18 @@
 }
 
 /* Flush single line comment */
-@media
-  screen and (min-resolution: 192dpi),
-  screen and (min-resolution: 2dppx) {
+@media screen and (min-resolution: 192dpi), screen and (min-resolution: 2dppx) {
   .selector {
     animation: 3s none fade-in;
-    background-image:
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        #fff 25px,
-        rgb(255 255 255 / 100%) 50px
-      );
+    background-image: repeating-linear-gradient(
+      -45deg,
+      transparent,
+      #fff 25px,
+      rgb(255 255 255 / 100%) 50px
+    );
     margin: 10px;
     margin-bottom: 5px;
-    box-shadow:
-      0 1px 1px #000,
-      0 1px 0 #fff,
-      2px 2px 1px 1px #ccc inset;
+    box-shadow: 0 1px 1px #000, 0 1px 0 #fff, 2px 2px 1px 1px #ccc inset;
     height: 10rem;
   }
 
@@ -90,8 +93,12 @@
 }
 
 @keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 // Prefer "simple" selector-not-notation

--- a/packages/stylelint-config/__tests__/valid.scss
+++ b/packages/stylelint-config/__tests__/valid.scss
@@ -1,6 +1,10 @@
 @import "x.css";
 @import "y.css";
 
+$one: "one";
+$two-kebab-case: "two";
+$media-query-width: 300px;
+
 /**
  * Multi-line comment
  */
@@ -45,6 +49,10 @@
 }
 
 /* Single-line comment */
+
+@media (min-width: $media-query-width) {
+  border: 1px solid black;
+}
 
 @media (width >= 60em) {
   .selector {

--- a/packages/stylelint-config/src/index.js
+++ b/packages/stylelint-config/src/index.js
@@ -59,6 +59,11 @@ module.exports = {
     // https://stylelint.io/user-guide/rules/media-feature-range-notation/
     'media-feature-range-notation': null,
 
+    // Rule is not appropriate when using SCSS variables with media queries.
+    // e.g. @media (max-width: $container-lg)
+    // https://stylelint.io/user-guide/rules/media-query-no-invalid/
+    'media-query-no-invalid': null,
+
     // Allows us to write duplicate selectors in groups
     // https://github.com/stylelint/stylelint/issues/3196
     'no-descending-specificity': [
@@ -130,7 +135,7 @@ module.exports = {
     'selector-id-pattern': [
       '^(([a-z][a-z0-9]*(-[a-z0-9]+)*)|([A-Z][a-z0-9]*)+)$',
       {
-        message: 'Expected id selector to be kebab-case or TitleCase',
+        message: 'Expected id selector to be kebab-case or TitleCase (selector-id-pattern)',
       },
     ],
 


### PR DESCRIPTION
| 🚥 Fixes ISSUE_ID |
| :---------------- |

## 🧰 Changes

Disables the `media-query-no-invalid` rule, which was enabled in the latest `stylelint-config-recommended` extension. We don't want to use it with SCSS.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
