### PR TITLE
fix: more prettier cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: monthly
     reviewers:
@@ -13,20 +13,7 @@ updates:
       prefix-development: chore(deps-dev)
 
   - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
-    reviewers:
-      - erunion
-    labels:
-      - dependencies
-    commit-message:
-      prefix: chore(deps)
-      prefix-development: chore(deps-dev)
-
-  - package-ecosystem: npm
-    directory: "/packages/eslint-config"
+    directory: '/'
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
@@ -39,7 +26,7 @@ updates:
       prefix-development: chore(deps-dev)
 
   - package-ecosystem: npm
-    directory: "/packages/spectral-config"
+    directory: '/packages/eslint-config'
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
@@ -52,7 +39,20 @@ updates:
       prefix-development: chore(deps-dev)
 
   - package-ecosystem: npm
-    directory: "/packages/stylelint-config"
+    directory: '/packages/spectral-config'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+    reviewers:
+      - erunion
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+
+  - package-ecosystem: npm
+    directory: '/packages/stylelint-config'
     schedule:
       interval: monthly
     open-pull-requests-limit: 10

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+*CHANGELOG.md

--- a/packages/eslint-config/prettier.js
+++ b/packages/eslint-config/prettier.js
@@ -1,0 +1,3 @@
+const prettier = require('./prettier.config');
+
+module.exports = prettier;

--- a/packages/spectral-config/README.md
+++ b/packages/spectral-config/README.md
@@ -26,6 +26,7 @@ extends: '@readme/spectral-config'
 >
 > This ruleset extends the core `oas` ruleset in Spectral. All of these rules are enabled by default.
 
+<!-- prettier-ignore -->
 | Rule | Description |
 | :--- | :--- |
 | `alex-component-summary` | Component schema summaries should have inclusive and considerate language. |

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -33,7 +33,7 @@ Create a `stylelint.config.js` file with the following contents:
 
 ```js
 module.exports = {
-  extends: "@readme/stylelint-config",
+  extends: '@readme/stylelint-config',
 };
 ```
 

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -32,5 +32,6 @@
   "devDependencies": {
     "@readme/eslint-config": "file:../eslint-config",
     "jest": "^29.4.3"
-  }
+  },
+  "prettier": "@readme/eslint-config/prettier"
 }


### PR DESCRIPTION
## 🧰 Changes

This PR brings back `packages/eslint-config/prettier.js` so the `@readme/eslint-config/prettier` shorthand works again. This PR also does some meta-housekeeping using Prettier:

- [x] Runs `npx prettier --write .` on every file in the codebase (minus the CHANGELOG files). I also decided against adding a check to CI for now.
- [x] Loads the Prettier config into the `stylelint-config` subpackage. Surprisingly, [this file](https://github.com/readmeio/standards/blob/40cdb30d3ce8c0d7e70e28e8a0f7ca04ca55fdb5/prettier.config.cjs#L1) appears to load in the config as expected 🧐

## 🧬 QA & Testing

Does the `@readme/eslint-config/prettier` shorthand work again?
