### PR TITLE
chore(spectral): point `alex` import to `index.js`

### DIFF
--- a/packages/spectral-config/package.json
+++ b/packages/spectral-config/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "NODE_OPTIONS='--no-deprecation' vitest run"
+    "test": "vitest run"
   },
   "repository": {
     "type": "git",

--- a/packages/spectral-config/src/functions/alex.js
+++ b/packages/spectral-config/src/functions/alex.js
@@ -5,7 +5,8 @@
  * @param {string} input
  */
 module.exports = async function alex(input, options, context) {
-  const { text } = await import('alex');
+  // eslint-disable-next-line import/extensions
+  const { text } = await import('alex/index.js');
   const errors = text(input, { profanitySureness: 1 }).messages;
 
   return errors


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

Per Jon's suggestion [here](https://github.com/readmeio/standards/pull/724#discussion_r1292443171), I was able to move the `NODE_OPTIONS='--no-deprecation'` that we previously needed for tests by importing `alex/index.js`.

## 🧬 QA & Testing

Do tests pass without a bunch of garbage input?
