### PR TITLE
fix(eslint/esm): enable `import/no-commonjs`

### DIFF
--- a/packages/eslint-config/esm.js
+++ b/packages/eslint-config/esm.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: ['plugin:require-extensions/recommended'],
   plugins: ['require-extensions', 'unicorn'],
   rules: {
+    'import/no-commonjs': 'error',
     'unicorn/prefer-node-protocol': 'error',
   },
 };


### PR DESCRIPTION
## 🧰 Changes

Enables the [`import/no-commonjs`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-commonjs.md) rule in our ESM-specific linting config.