### PR TITLE
ci(eslint-config): add lightweight type-checking

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 *CHANGELOG.md
+packages/spectral-config/dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -4319,6 +4319,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.198",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
+      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.merge": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
+      "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
@@ -8242,6 +8257,27 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-define-config": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/eslint-define-config/-/eslint-define-config-1.23.0.tgz",
+      "integrity": "sha512-4mMyu0JuBkQHsCtR+42irIQdFLmLIW+pMAVcyOV/gZRL4O1R8iuH0eMG3oL3Cbi1eo9fDAfT5CIHVHgdyxcf6w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/Shinigami92"
+        },
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.com/donate/?hosted_button_id=L7GY729FBKTZY"
+        }
+      ],
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0",
+        "npm": ">=7.0.0",
+        "pnpm": ">= 8.6.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -21278,6 +21314,11 @@
         "eslint-plugin-vitest": "^0.3.1",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
         "lodash.merge": "^4.6.2"
+      },
+      "devDependencies": {
+        "@types/lodash.merge": "^4.6.7",
+        "eslint-define-config": "^1.23.0",
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "prettier": "prettier --check .",
     "prepare": "husky install",
     "version": "npm i && git add package-lock.json",
-    "release": "npx lerna publish",
-    "test": "npx lerna run test --stream"
+    "release": "lerna publish",
+    "test": "lerna run test --stream"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config/esm.js
+++ b/packages/eslint-config/esm.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: ['plugin:require-extensions/recommended'],
   plugins: ['require-extensions', 'unicorn'],
   rules: {
+    'import/no-commonjs': 'error',
     'unicorn/prefer-node-protocol': 'error',
   },
 };

--- a/packages/eslint-config/esm.js
+++ b/packages/eslint-config/esm.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = {
   extends: ['plugin:require-extensions/recommended'],
   plugins: ['require-extensions', 'unicorn'],
   rules: {
@@ -6,3 +7,5 @@ module.exports = {
     'unicorn/prefer-node-protocol': 'error',
   },
 };
+
+module.exports = config;

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,6 +1,7 @@
 const prettierConfig = require('./prettier.config');
 
-module.exports = {
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = {
   extends: [
     'airbnb-base',
     'eslint:recommended',
@@ -90,3 +91,5 @@ module.exports = {
     'you-dont-need-lodash-underscore/throttle': 'off',
   },
 };
+
+module.exports = config;

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prettier": "prettier --list-different --write \"./**/**.js\"",
     "lint": "eslint .",
-    "test": "eslint ."
+    "test": "tsc"
   },
   "publishConfig": {
     "access": "public"
@@ -47,5 +47,10 @@
   "peerDependencies": {
     "eslint": "^8.0.0",
     "prettier": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/lodash.merge": "^4.6.7",
+    "eslint-define-config": "^1.23.0",
+    "typescript": "^5.2.2"
   }
 }

--- a/packages/eslint-config/prettier.config.js
+++ b/packages/eslint-config/prettier.config.js
@@ -1,5 +1,8 @@
-module.exports = {
+/** @type {import("prettier").Config} */
+const config = {
   arrowParens: 'avoid',
   printWidth: 120,
   singleQuote: true,
 };
+
+module.exports = config;

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = {
   extends: ['plugin:jsx-a11y/recommended', 'plugin:react/recommended', 'plugin:react-hooks/recommended'],
   env: {
     browser: true,
@@ -39,3 +40,5 @@ module.exports = {
     ],
   },
 };
+
+module.exports = config;

--- a/packages/eslint-config/testing/common.config.js
+++ b/packages/eslint-config/testing/common.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = {
   plugins: ['import', 'node'],
   rules: {
     'func-names': 'off',
@@ -13,3 +14,5 @@ module.exports = {
     'require-await': 'error',
   },
 };
+
+module.exports = config;

--- a/packages/eslint-config/testing/jest-dom.js
+++ b/packages/eslint-config/testing/jest-dom.js
@@ -2,6 +2,9 @@ const merge = require('lodash.merge');
 
 const jest = require('./jest');
 
-module.exports = merge(jest, {
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = merge(jest, {
   extends: ['plugin:jest-dom/recommended'],
 });
+
+module.exports = config;

--- a/packages/eslint-config/testing/jest.js
+++ b/packages/eslint-config/testing/jest.js
@@ -2,7 +2,8 @@ const merge = require('lodash.merge');
 
 const common = require('./common.config');
 
-module.exports = merge(common, {
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = merge(common, {
   extends: ['plugin:jest/recommended', 'plugin:jest/style', 'plugin:jest-formatting/recommended'],
   env: {
     'jest/globals': true,
@@ -19,3 +20,5 @@ module.exports = merge(common, {
     'jest/require-to-throw-message': 'error',
   },
 });
+
+module.exports = config;

--- a/packages/eslint-config/testing/react.js
+++ b/packages/eslint-config/testing/react.js
@@ -1,3 +1,6 @@
-module.exports = {
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = {
   extends: ['plugin:testing-library/react'],
 };
+
+module.exports = config;

--- a/packages/eslint-config/testing/vitest.js
+++ b/packages/eslint-config/testing/vitest.js
@@ -2,7 +2,8 @@ const merge = require('lodash.merge');
 
 const common = require('./common.config');
 
-module.exports = merge(common, {
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = merge(common, {
   extends: ['plugin:vitest/all'],
   rules: {
     'vitest/max-expects': 'off',
@@ -18,3 +19,5 @@ module.exports = merge(common, {
     'vitest/require-top-level-describe': 'off',
   },
 });
+
+module.exports = config;

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "CommonJS",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true
+  }
+}

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "checkJs": true,
-    "forceConsistentCasingInFileNames": true,
     "module": "CommonJS",
     "noEmit": true,
     "skipLibCheck": true,

--- a/packages/eslint-config/typescript.js
+++ b/packages/eslint-config/typescript.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:typescript-sort-keys/recommended'],
@@ -53,3 +54,5 @@ module.exports = {
     '@typescript-eslint/no-shadow': ['error'],
   },
 };
+
+module.exports = config;


### PR DESCRIPTION
## 🧰 Changes

I've been feeling a little uneasy for sometime about the fact that there's no great way in the ESLint ecosystem to validate shared configs like ours. I discovered [`eslint-define-config`](https://github.com/Shinigami92/eslint-define-config) (in lieu of ESLint exporting their own types, which sadly [they've confirmed they have no plans to do](https://github.com/eslint/eslint/issues/14249)) which seems great and well-maintained, so I brought that in and added a little `tsconfig` so we can start type-checking our existing JS files. Hopefully this will make it easier to maintain our configs over time.

Prettier is great and maintains their own types so I also brought those in.

## 🧬 QA & Testing

The good (but generally slightly concerning) thing is we don't have any errors that this flagged, but I confirmed locally that tests fail if you add garbage data to any of these configs.
