### PR TITLE
feat(eslint/esm): enable more ESM rules

### DIFF
--- a/packages/eslint-config/esm.js
+++ b/packages/eslint-config/esm.js
@@ -3,7 +3,11 @@ const config = {
   extends: ['plugin:require-extensions/recommended'],
   plugins: ['require-extensions', 'unicorn'],
   rules: {
+    // see here for more rules to possibly enable in the future:
+    // https://gist.github.com/Jaid/164668c0151ae09d2bc81be78a203dd5
     'import/no-commonjs': 'error',
+    'node/no-extraneous-import': 'error',
+    'unicorn/prefer-module': 'error',
     'unicorn/prefer-node-protocol': 'error',
   },
 };


### PR DESCRIPTION
## 🧰 Changes

This PR enables two rules in our ESM config:
1. **[`unicorn/prefer-module`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-module.md)** — this came up as a result of https://github.com/readmeio/oas-to-har/pull/243 — this rule will prevent a variety of Node/CommonJS usage patterns, such as `__dirname`, `require`, and `module.exports` _(this rule slaps)_
2. **[`node/no-extraneous-import`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-extraneous-import.md)** — basically the ESM equivalent of [`node/no-extraneous-require`](https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-extraneous-require.md)

There are a slew of suggested ESM configuration options listed in [this gist](https://gist.github.com/Jaid/164668c0151ae09d2bc81be78a203dd5), but I decided to only enable these ones for now.

## 🧬 QA & Testing

Have I mentioned that the `eslint-define-config` types that we have in this repo are extremely handy?
