### PR TITLE
feat(stylelint-config): allow zero units for css props

### DIFF
--- a/packages/stylelint-config/__tests__/valid.scss
+++ b/packages/stylelint-config/__tests__/valid.scss
@@ -11,6 +11,7 @@ $media-query-width: 300px;
 
 :root {
   --brand-red: rgb(112, 94, 92);
+  --zero-unit: 0px;
 }
 
 #id-selector {

--- a/packages/stylelint-config/src/index.js
+++ b/packages/stylelint-config/src/index.js
@@ -51,6 +51,18 @@ module.exports = {
       },
     ],
 
+    // Allows zero length units when defined by custom CSS properties. There are
+    // cases where we often use the "calc" function to perform operations on CSS
+    // properties, e.g. `calc(100% - var(--sponge) - var(--bob))`. Those always
+    // require units to work properly, including 0 values.
+    // https://stylelint.io/user-guide/rules/length-zero-no-unit
+    'length-zero-no-unit': [
+      true,
+      {
+        ignore: ['custom-properties'],
+      },
+    ],
+
     // ReadMe breaks this rule in many places.
     'max-nesting-depth': null,
 


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

Allows zero length units when defined by custom CSS properties. There are
cases where we often use the "calc" function to perform operations on CSS
properties, e.g. `calc(100% - var(--sponge) - var(--bob))`. Those always
require units to work properly, including 0 values.

https://stylelint.io/user-guide/rules/length-zero-no-unit


## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
