### PR TITLE
feat(eslint-config): dropping use of `eslint-plugin-prettier`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23790,7 +23790,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^8.0.0"
+        "eslint": "^8.0.0",
+        "prettier": "^3.0.0"
       }
     },
     "packages/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23761,7 +23761,7 @@
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-prettier": "^9.0.0",
+        "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.28.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@commitlint/cli": "^19.2.1",
         "@commitlint/config-conventional": "^19.1.0",
         "husky": "^9.0.11",
-        "lerna": "^8.1.2"
+        "lerna": "^8.1.2",
+        "prettier": "^3.2.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3841,17 +3842,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@pkgr/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
-      }
-    },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
@@ -5184,19 +5174,10 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.198",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
-    },
-    "node_modules/@types/lodash.merge": {
-      "version": "4.6.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.9.tgz",
-      "integrity": "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.12",
@@ -10126,35 +10107,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
-      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.8.6"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": "*",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.34.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.1.tgz",
@@ -15070,6 +15022,7 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
@@ -18777,10 +18730,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
-      "peer": true,
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21036,26 +20988,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
-    },
-    "node_modules/synckit": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
-      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
-      "dependencies": {
-        "@pkgr/core": "^0.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
-      }
-    },
-    "node_modules/synckit/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/table": {
       "version": "6.8.1",
@@ -23838,7 +23770,6 @@
         "eslint-plugin-jest-formatting": "^3.0.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-readme": "file:../eslint-plugin",
@@ -23848,10 +23779,10 @@
         "eslint-plugin-unicorn": "^51.0.1",
         "eslint-plugin-vitest": "^0.4.1",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
-        "lodash.merge": "^4.6.2"
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "@types/lodash.merge": "^4.6.7",
+        "@types/lodash": "^4.17.0",
         "eslint-define-config": "^2.0.0",
         "typescript": "^5.4.3"
       },
@@ -23859,8 +23790,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^8.0.0",
-        "prettier": "^3.0.0"
+        "eslint": "^8.0.0"
       }
     },
     "packages/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@commitlint/cli": "^19.2.1",
     "@commitlint/config-conventional": "^19.1.0",
     "husky": "^9.0.11",
-    "lerna": "^8.1.2"
+    "lerna": "^8.1.2",
+    "prettier": "^3.2.5"
   },
   "commitlint": {
     "extends": [

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,13 +1,3 @@
-// The following are ESLint rules that collide with our Prettier config. If we don't disable these
-// then code formatted by Prettier will cause ESLint to throw errors.
-const prettierOverrides = {
-  'arrow-body-style': 'off',
-  'arrow-parens': 'off',
-  'object-curly-newline': 'off',
-  'operator-linebreak': 'off',
-  'prefer-arrow-callback': 'off',
-};
-
 /** @type {import("eslint-define-config").ESLintConfig} */
 const config = {
   extends: [
@@ -17,11 +7,11 @@ const config = {
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:you-dont-need-lodash-underscore/compatible',
+    'prettier',
   ],
   plugins: ['node', 'unicorn'],
-  // @ts-ignore `prettierOverrides` is compatible with `rules` this isn't TS for us to type that.
   rules: {
-    ...prettierOverrides,
+    'arrow-body-style': 'off', // This rule is handled by our Prettier config.
 
     'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
     'eslint-comments/no-unused-disable': 'error',
@@ -63,6 +53,7 @@ const config = {
     'node/no-exports-assign': 'error',
     'node/no-extraneous-require': 'error',
 
+    'prefer-arrow-callback': 'off', // This rule is handled by our Prettier config.
     'prefer-destructuring': 'off',
 
     // The `eslint-config-airbnb-base` that we extend off of doesn't have any rules for catching for

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -11,7 +11,7 @@ const config = {
   ],
   plugins: ['node', 'unicorn'],
   rules: {
-    'arrow-body-style': 'off', // This rule is handled by our Prettier config.
+    'arrow-body-style': 'off', // This rule clashes with our Prettier config.
 
     'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
     'eslint-comments/no-unused-disable': 'error',
@@ -53,7 +53,7 @@ const config = {
     'node/no-exports-assign': 'error',
     'node/no-extraneous-require': 'error',
 
-    'prefer-arrow-callback': 'off', // This rule is handled by our Prettier config.
+    'prefer-arrow-callback': 'off', // This rule clashes with our Prettier config.
     'prefer-destructuring': 'off',
 
     // The `eslint-config-airbnb-base` that we extend off of doesn't have any rules for catching for

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -19,6 +19,7 @@ const config = {
     'plugin:you-dont-need-lodash-underscore/compatible',
   ],
   plugins: ['node', 'unicorn'],
+  // @ts-ignore `prettierOverrides` is compatible with `rules` this isn't TS for us to type that.
   rules: {
     ...prettierOverrides,
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -54,14 +54,6 @@ const config = {
 
     'prefer-destructuring': 'off',
 
-    'prettier/prettier': [
-      'error',
-      prettierConfig,
-      {
-        usePrettierrc: false,
-      },
-    ],
-
     // The `eslint-config-airbnb-base` that we extend off of doesn't have any rules for catching for
     // templated strings that aren't templates.
     quotes: ['error', 'single', { avoidEscape: true }],

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -3,6 +3,7 @@
 const prettierOverrides = {
   'arrow-body-style': 'off',
   'arrow-parens': 'off',
+  'object-curly-newline': 'off',
   'operator-linebreak': 'off',
   'prefer-arrow-callback': 'off',
 };

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,4 +1,11 @@
-const prettierConfig = require('./prettier.config');
+// The following are ESLint rules that collide with our Prettier config. If we don't disable these
+// then code formatted by Prettier will cause ESLint to throw errors.
+const prettierOverrides = {
+  'arrow-body-style': 'off',
+  'arrow-parens': 'off',
+  'operator-linebreak': 'off',
+  'prefer-arrow-callback': 'off',
+};
 
 /** @type {import("eslint-define-config").ESLintConfig} */
 const config = {
@@ -9,10 +16,11 @@ const config = {
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:you-dont-need-lodash-underscore/compatible',
-    'plugin:prettier/recommended', // This has to be the last rule added.
   ],
   plugins: ['node', 'unicorn'],
   rules: {
+    ...prettierOverrides,
+
     'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
     'eslint-comments/no-unused-disable': 'error',
 
@@ -45,7 +53,8 @@ const config = {
 
     'no-restricted-imports': ['error', { paths: ['lodash'] }],
 
-    // Disallow shadowing of any variable that isn't "err" as this is a common case that is acceptable.
+    // Disallow shadowing of any variable that isn't "err" as this is a common case that is
+    // acceptable.
     'no-shadow': ['error', { allow: ['err'] }],
 
     'node/no-deprecated-api': 'error',
@@ -78,7 +87,8 @@ const config = {
     'unicorn/prefer-type-error': 'error',
     'unicorn/throw-new-error': 'error',
 
-    // We're comfortable using throttle and debounce out of Lodash instead of polyfilling them with something else.
+    // We're comfortable using throttle and debounce out of Lodash instead of polyfilling them with
+    // something else.
     'you-dont-need-lodash-underscore/debounce': 'off',
     'you-dont-need-lodash-underscore/throttle': 'off',
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,7 +24,7 @@
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-prettier": "^9.0.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.28.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,6 @@
     "eslint-plugin-jest-formatting": "^3.0.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-readme": "file:../eslint-plugin",
@@ -43,14 +42,13 @@
     "eslint-plugin-unicorn": "^51.0.1",
     "eslint-plugin-vitest": "^0.4.1",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
-    "lodash.merge": "^4.6.2"
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "eslint": "^8.0.0",
-    "prettier": "^3.0.0"
+    "eslint": "^8.0.0"
   },
   "devDependencies": {
-    "@types/lodash.merge": "^4.6.7",
+    "@types/lodash": "^4.17.0",
     "eslint-define-config": "^2.0.0",
     "typescript": "^5.4.3"
   }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -45,7 +45,8 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "eslint": "^8.0.0"
+    "eslint": "^8.0.0",
+    "prettier": "^3.0.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.0",

--- a/packages/eslint-config/testing/jest-dom.js
+++ b/packages/eslint-config/testing/jest-dom.js
@@ -1,4 +1,4 @@
-const merge = require('lodash.merge');
+const merge = require('lodash/merge');
 
 const jest = require('./jest');
 

--- a/packages/eslint-config/testing/jest.js
+++ b/packages/eslint-config/testing/jest.js
@@ -1,4 +1,4 @@
-const merge = require('lodash.merge');
+const merge = require('lodash/merge');
 
 const common = require('./common.config');
 

--- a/packages/eslint-config/testing/vitest.js
+++ b/packages/eslint-config/testing/vitest.js
@@ -1,4 +1,4 @@
-const merge = require('lodash.merge');
+const merge = require('lodash/merge');
 
 const common = require('./common.config');
 


### PR DESCRIPTION
## 🧰 Changes

We're dropping use of `eslint-plugin-prettier` within our main ESLint config as we've been experiencing some performance setbacks with it in our large codebase. Instead we now recommend running Prettier separately alongside ESLint (which `typescript-eslint` also recommends doing[^1]).

[^1]: https://typescript-eslint.io/troubleshooting/performance-troubleshooting/#eslint-plugin-prettier