### PR TITLE
feat(eslint-config): pulling in `eslint-plugin-try-catch-failsafe`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8167,6 +8167,14 @@
         "eslint": "^7.5.0 || ^8.0.0"
       }
     },
+    "node_modules/eslint-plugin-try-catch-failsafe": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-try-catch-failsafe/-/eslint-plugin-try-catch-failsafe-0.1.4.tgz",
+      "integrity": "sha512-IeGXMEVBR+t6wof4gq00guRgAoDgcyz7nMoI7PInFSERwY43F5NdJV9fYH46pZdZFOHOpSwkpwG2NouubD/vMA==",
+      "dependencies": {
+        "requireindex": "^1.2.0"
+      }
+    },
     "node_modules/eslint-plugin-typescript-sort-keys": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-3.2.0.tgz",
@@ -19691,6 +19699,7 @@
         "eslint-plugin-readme": "file:../eslint-plugin",
         "eslint-plugin-require-extensions": "^0.1.3",
         "eslint-plugin-testing-library": "^6.0.1",
+        "eslint-plugin-try-catch-failsafe": "^0.1.4",
         "eslint-plugin-typescript-sort-keys": "^3.2.0",
         "eslint-plugin-unicorn": "^55.0.0",
         "eslint-plugin-vitest": "^0.5.4",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -6,6 +6,7 @@ const config = {
     'plugin:eslint-comments/recommended',
     'plugin:import/errors',
     'plugin:import/warnings',
+    'plugin:try-catch-failsafe/default',
     'plugin:you-dont-need-lodash-underscore/compatible',
     'prettier',
   ],

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-readme": "file:../eslint-plugin",
     "eslint-plugin-require-extensions": "^0.1.3",
     "eslint-plugin-testing-library": "^6.0.1",
+    "eslint-plugin-try-catch-failsafe": "^0.1.4",
     "eslint-plugin-typescript-sort-keys": "^3.2.0",
     "eslint-plugin-unicorn": "^55.0.0",
     "eslint-plugin-vitest": "^0.5.4",


### PR DESCRIPTION
## 🧰 Changes

This pulls in [eslint-plugin-try-catch-failsafe](https://github.com/RexSkz/eslint-plugin-try-catch-failsafe) in order for us to better catch cases where `JSON.parse()` and `new URL()` aren't wrapped in try-catch blocks.