### PR TITLE
release(v15): ESLint 9 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8155,16 +8155,6 @@
         }
       }
     },
-    "node_modules/eslint-plugin-jest-formatting": {
-      "version": "3.1.0",
-      "integrity": "sha512-XyysraZ1JSgGbLSDxjj5HzKKh0glgWf+7CkqxbTqb7zEhW7X2WHo5SBQ8cGhnszKN+2Lj3/oevBlHNbHezoc/A==",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=0.8.0"
-      }
-    },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
@@ -20439,7 +20429,6 @@
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-jest": "^28.3.0",
         "eslint-plugin-jest-dom": "^5.2.0",
-        "eslint-plugin-jest-formatting": "^3.0.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-perfectionist": "^4.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20488,7 +20488,6 @@
       "license": "ISC",
       "devDependencies": {
         "@babel/eslint-parser": "^7.27.1",
-        "@readme/eslint-config": "file:../eslint-config",
         "@typescript-eslint/parser": "^8.24.1",
         "eslint-doc-generator": "^2.0.2",
         "vitest": "^3.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20459,7 +20459,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "eslint": "^8.0.0",
@@ -20478,7 +20478,7 @@
         "vitest": "^3.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "eslint": "^8.0.0"
@@ -20500,7 +20500,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@stoplight/spectral-cli": "^6.6.0"
@@ -20524,7 +20524,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.4.12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -957,9 +957,10 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -7394,6 +7395,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -7744,6 +7758,21 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-config-airbnb-base": {
       "version": "15.0.0",
       "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
@@ -7995,41 +8024,25 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "license": "MIT",
       "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
       },
       "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=4.19.1"
-      }
-    },
-    "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "engines": {
-        "node": ">=4"
+        "eslint": ">=8"
       }
     },
     "node_modules/eslint-plugin-eslint-comments": {
@@ -8187,50 +8200,65 @@
       "version": "9.2.2",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-n": {
+      "version": "17.18.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.18.0.tgz",
+      "integrity": "sha512-hvZ/HusueqTJ7VDLoCpjN0hx4N4+jHIWTXD4TMLHy9F23XkDagR9v+xQWRWR57yY55GPF8NnD4ox9iGTxirY8A==",
+      "license": "MIT",
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "@eslint-community/eslint-utils": "^4.5.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-plugin-es-x": "^7.8.0",
+        "get-tsconfig": "^4.8.1",
+        "globals": "^15.11.0",
+        "ignore": "^5.3.2",
+        "minimatch": "^9.0.5",
+        "semver": "^7.6.3"
       },
       "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.23.0"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+    "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
+    "node_modules/eslint-plugin-n/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
@@ -16175,16 +16203,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
     "node_modules/registry-auth-token": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
@@ -18002,6 +18020,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/tapable": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tar": {
       "version": "6.2.1",
@@ -20430,7 +20457,7 @@
         "eslint-plugin-jest": "^28.3.0",
         "eslint-plugin-jest-dom": "^5.2.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-n": "^17.18.0",
         "eslint-plugin-perfectionist": "^4.9.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.0.0",

--- a/packages/eslint-config/esm.js
+++ b/packages/eslint-config/esm.js
@@ -7,7 +7,7 @@ const config = {
     // https://gist.github.com/Jaid/164668c0151ae09d2bc81be78a203dd5
     'import/no-commonjs': 'error',
 
-    'node/no-extraneous-import': 'error',
+    'n/no-extraneous-import': 'error',
     'unicorn/prefer-module': 'error',
     'unicorn/prefer-node-protocol': 'error',
   },

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -10,7 +10,7 @@ const config = {
     'plugin:you-dont-need-lodash-underscore/compatible',
     'prettier',
   ],
-  plugins: ['node', 'unicorn'],
+  plugins: ['n', 'unicorn'],
   rules: {
     'arrow-body-style': 'off', // This rule clashes with our Prettier config.
 
@@ -50,9 +50,9 @@ const config = {
     // acceptable.
     'no-shadow': ['error', { allow: ['err'] }],
 
-    'node/no-deprecated-api': 'error',
-    'node/no-exports-assign': 'error',
-    'node/no-extraneous-require': 'error',
+    'n/no-deprecated-api': 'error',
+    'n/no-exports-assign': 'error',
+    'n/no-extraneous-require': 'error',
 
     'prefer-arrow-callback': 'off', // This rule clashes with our Prettier config.
     'prefer-destructuring': 'off',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,7 +32,6 @@
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jest": "^28.3.0",
     "eslint-plugin-jest-dom": "^5.2.0",
-    "eslint-plugin-jest-formatting": "^3.0.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-perfectionist": "^4.9.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-jest": "^28.3.0",
     "eslint-plugin-jest-dom": "^5.2.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^17.18.0",
     "eslint-plugin-perfectionist": "^4.9.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.0.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/readmeio/standards#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "lint": "eslint .",

--- a/packages/eslint-config/testing/common.config.js
+++ b/packages/eslint-config/testing/common.config.js
@@ -1,6 +1,6 @@
 /** @type {import("eslint-define-config").ESLintConfig} */
 const config = {
-  plugins: ['import', 'node'],
+  plugins: ['import', 'n'],
   rules: {
     // A failing `JSON.parse()` will fail the unit test it's in so it's safe to ignore.
     'try-catch-failsafe/json-parse': 'off',
@@ -9,7 +9,7 @@ const config = {
 
     'import/no-extraneous-dependencies': 'off',
 
-    'node/no-extraneous-require': 'off',
+    'n/no-extraneous-require': 'off',
 
     // Sniff out tests that have useless `async` declarations. Since there's valid usecases for
     // having a function be async and not return or await a Promise, we're only running this rule

--- a/packages/eslint-config/testing/jest.js
+++ b/packages/eslint-config/testing/jest.js
@@ -4,18 +4,28 @@ const common = require('./common.config');
 
 /** @type {import("eslint-define-config").ESLintConfig} */
 const config = merge(common, {
-  extends: ['plugin:jest/recommended', 'plugin:jest/style', 'plugin:jest-formatting/recommended'],
+  extends: ['plugin:jest/recommended', 'plugin:jest/style'],
   env: {
     'jest/globals': true,
   },
   rules: {
     'jest/consistent-test-it': ['warn', { fn: 'test', withinDescribe: 'it' }],
+
     'jest/no-disabled-tests': 'off',
     'jest/no-duplicate-hooks': 'warn',
+
+    'jest/padding-around-after-all-blocks': 'warn',
+    'jest/padding-around-after-each-blocks': 'warn',
+    'jest/padding-around-before-all-blocks': 'warn',
+    'jest/padding-around-before-each-blocks': 'warn',
+    'jest/padding-around-describe-blocks': 'warn',
+    'jest/padding-around-test-blocks': 'warn',
+
     'jest/prefer-expect-resolves': 'warn',
     'jest/prefer-hooks-on-top': 'warn',
     'jest/prefer-strict-equal': 'error',
     'jest/prefer-todo': 'warn',
+
     'jest/require-to-throw-message': 'error',
   },
 });

--- a/packages/eslint-plugin/.eslintrc
+++ b/packages/eslint-plugin/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "@readme/eslint-config",
-  "parserOptions": {
-    "ecmaVersion": 2022
-  }
-}

--- a/packages/eslint-plugin/eslint.config.mjs
+++ b/packages/eslint-plugin/eslint.config.mjs
@@ -1,0 +1,13 @@
+import eslint from '@eslint/js';
+import globals from 'globals';
+
+/** @type {import("eslint-define-config").ESLintConfig} */
+const config = {
+  languageOptions: {
+    globals: {
+      ...globals.node,
+    },
+  },
+};
+
+export default [eslint.configs.recommended, config];

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.27.1",
-    "@readme/eslint-config": "file:../eslint-config",
     "@typescript-eslint/parser": "^8.24.1",
     "eslint-doc-generator": "^2.0.2",
     "vitest": "^3.1.2"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/readmeio/standards#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/spectral-config/package.json
+++ b/packages/spectral-config/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -8,7 +8,7 @@
     "test": "vitest run"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🧰 Changes

* [x] Dropping support for Node 18.
* [x] Replacing `eslint-plugin-node` with `eslint-plugin-n`
* [x] Removing `eslint-plugin-jest-formatting`
* [ ] Replacing `eslint-plugin-import` with `eslint-plugin-import-x`
* [ ] Moving `eslint-config-airbnb-base` in house
* [x] Removing a circular dependency on `eslint-config` from inside `eslint-plugin`
* [ ] Moving `eslint-plugin` over to a flat config
* [ ] Moving `eslint-config` over to a flat config
